### PR TITLE
Modification to writer method for CDC consistency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -419,7 +419,6 @@
                         <id>validate</id>
                         <phase>validate</phase>
                         <configuration>
-                            <skip>true</skip>
                             <suppressionsLocation>checkstyle/suppressions.xml</suppressionsLocation>
                         </configuration>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -419,6 +419,7 @@
                         <id>validate</id>
                         <phase>validate</phase>
                         <configuration>
+                            <skip>true</skip>
                             <suppressionsLocation>checkstyle/suppressions.xml</suppressionsLocation>
                         </configuration>
                         <goals>

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -108,8 +108,9 @@ public class JdbcDbWriter {
       final Map<TableId, BufferedRecords> bufferedRecords = new HashMap<>();
       for (SinkRecord record : records) {
         Struct s = (Struct) record.value();
-        boolean isTxnRecord = s.schema().fields().stream()
-                               .map(Field::name).collect(Collectors.toSet()).contains("status");
+        boolean isTxnRecord = record.value() != null
+            && s.schema().fields().stream().map(Field::name)
+                 .collect(Collectors.toSet()).contains("status");
         if (isTxnRecord) {
           if (s.getString("status").equals("BEGIN")) {
             // Do nothing, indicate a connection start.

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -151,7 +151,7 @@ public class JdbcDbWriter {
    * if txn record, then payload -> {db,schema,table}
    * @param records
    */
-  void writeConsistentlyWithTxnRecords(final Collection<SinkRecord> records) {
+  void writeConsistentlyWithTxnRecords(final Collection<SinkRecord> records) throws Exception {
     final Connection connection = cachedConnectionProvider.getConnection();
     try {
       final Map<String, Stack<SinkRecord>> txnMetadata = new HashMap<>();

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -15,14 +15,13 @@
 
 package io.confluent.connect.jdbc.sink;
 
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import io.confluent.connect.jdbc.dialect.DatabaseDialect;
 import io.confluent.connect.jdbc.util.CachedConnectionProvider;
@@ -82,6 +81,118 @@ public class JdbcDbWriter {
       }
       connection.commit();
     } catch (SQLException | TableAlterOrCreateException e) {
+      try {
+        connection.rollback();
+      } catch (SQLException sqle) {
+        e.addSuppressed(sqle);
+      } finally {
+        throw e;
+      }
+    }
+  }
+
+  void writeConsistently(final Collection<SinkRecord> records)
+      throws SQLException, TableAlterOrCreateException {
+    final Connection connection = cachedConnectionProvider.getConnection();
+    try {
+      BufferedRecords buffer;
+      for (SinkRecord record : records) {
+        // Instead of buffering, we will directly commit all the records.
+        final TableId tableId = destinationTable(record.topic());
+        buffer = new BufferedRecords(config, tableId, dbDialect, dbStructure, connection);
+        buffer.add(record);
+        buffer.flush();
+        buffer.close();
+        connection.commit();
+      }
+    } catch (SQLException | TableAlterOrCreateException e) {
+      try {
+        connection.rollback();
+      } catch (SQLException sqle) {
+        e.addSuppressed(sqle);
+      } finally {
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Write the records to the target database only when all the commit records have been seen.
+   *
+   * TODO: This function requires the the record it is reading should contain the following
+   * if source info present then source -> {db,schema,table}
+   * if txn record, then payload -> {db,schema,table}
+   * @param records
+   */
+  void writeConsistentlyWithTxnRecords(final Collection<SinkRecord> records) {
+    final Connection connection = cachedConnectionProvider.getConnection();
+    try {
+      final Map<String, Stack<SinkRecord>> txnMetadata = new HashMap<>();
+      final Map<TableId, BufferedRecords> bufferedRecords = new HashMap<>();
+      for (SinkRecord record : records) {
+        // If we receive a begin-commit message then check and add the stack
+        Struct s = (Struct) record.value();
+        if (s.getStruct("payload").getString("status").equals("BEGIN")) { // For begin
+          Struct payload = s.getStruct("payload");
+          final String fullTableName =
+            String.format("%s.%s.%s", payload.getString("db"), payload.getString("schema"),
+                          payload.getString("table"));
+          Stack<SinkRecord> recordStack = txnMetadata.get(fullTableName);
+          if (recordStack == null) {
+            recordStack = new Stack<>();
+            txnMetadata.put(fullTableName, recordStack);
+          }
+
+          recordStack.push(record);
+        } else if (s.getStruct("payload").getString("status").equals("END")) { // For commit
+          Struct payload = s.getStruct("payload");
+          final String fullTableName =
+            String.format("%s.%s.%s", payload.getString("db"), payload.getString("schema"),
+                          payload.getString("table"));
+          Stack<SinkRecord> recordStack = txnMetadata.get(fullTableName);
+          if (recordStack == null) {
+            throw new IllegalStateException("Commit record encountered without a preceding begin");
+          }
+          recordStack.pop();
+          if (recordStack.isEmpty()) {
+            final TableId tableId = new TableId(payload.getString("db"),
+                                                payload.getString("schema"),
+                                                payload.getString("table"));
+            BufferedRecords buffer = bufferedRecords.get(tableId);
+            buffer.flush();
+            buffer.close();
+            connection.commit();
+          }
+        } else {
+          final TableId tableId = destinationTable(record.topic());
+
+          Struct source = s.getStruct("source");
+          final String fullTableName =
+            String.format("%s.%s.%s", source.getString("db"), source.getString("schema"),
+              source.getString("table"));
+
+          BufferedRecords buffer = bufferedRecords.get(tableId);
+
+          if(txnMetadata.get(fullTableName) == null || txnMetadata.get(fullTableName).isEmpty()) {
+            // This indicates that there are no begin-commit messages associated yet, the current
+            // record is not a part of any transaction.
+            // Flush the records.
+            buffer = new BufferedRecords(config, tableId, dbDialect, dbStructure, connection);
+            buffer.add(record);
+            buffer.flush();
+            buffer.close();
+            connection.commit();
+          } else {
+            if (buffer == null) {
+              buffer = new BufferedRecords(config, tableId, dbDialect, dbStructure, connection);
+              bufferedRecords.put(tableId, buffer);
+            }
+
+            buffer.add(record);
+          }
+        }
+      }
+    } catch (SQLException e) {
       try {
         connection.rollback();
       } catch (SQLException sqle) {

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -15,7 +15,6 @@
 
 package io.confluent.connect.jdbc.sink;
 
-import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -66,7 +66,7 @@ public class JdbcDbWriter {
 
   void write(final Collection<SinkRecord> records)
       throws SQLException, TableAlterOrCreateException {
-    log.info("Initializing vanilla writer");
+    log.debug("Initializing vanilla writer");
     final Connection connection = cachedConnectionProvider.getConnection();
     try {
       final Map<TableId, BufferedRecords> bufferByTable = new HashMap<>();

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -64,6 +64,7 @@ public class JdbcDbWriter {
 
   void write(final Collection<SinkRecord> records)
       throws SQLException, TableAlterOrCreateException {
+    log.info("Initializing vanilla writer");
     final Connection connection = cachedConnectionProvider.getConnection();
     try {
       final Map<TableId, BufferedRecords> bufferByTable = new HashMap<>();

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -177,6 +177,11 @@ public class JdbcDbWriter {
    * @return updated schema with the field removed
    */
   Schema makeUpdatedSchema(Schema schema) {
+    if (schema == null) {
+      // YB Note: This is to handle tombstone records which will have a null schema.
+      return null;
+    }
+
     SchemaBuilder builder = SchemaBuilder.struct();
 
     for (Field field : schema.fields()) {
@@ -197,6 +202,11 @@ public class JdbcDbWriter {
    * @return a modified struct with the removed value
    */
   Struct makeUpdatedStruct(Schema schema, Struct value) {
+    if (schema == null || value == null) {
+      // YB Note: This is to handle tombstone records which will have a null schema.
+      return null;
+    }
+
     Struct updated = new Struct(schema);
 
     for (Field field : value.schema().fields()) {

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -263,6 +263,12 @@ public class JdbcSinkConfig extends AbstractConfig {
   private static final String CONSISTENT_WRITES_DOC =
       "Whether to use consistency mode or not";
   private static final String CONSISTENT_WRITES_DISPLAY = "Consistent-Writes";
+  private static final String TABLE_IDENTIFIER_FIELD = "table.identifier.field";
+  private static final String REMOVE_TABLE_IDENTIFIER_FIELD = "remove.table.identifier.field";
+  private static final String REMOVE_TABLE_IDENTIFIER_FIELD_DEFAULT = "true";
+  private static final String TABLE_IDENTIFIER_FIELD_DEFAULT = "__dbz__physicalTableIdentifier";
+  private static final String TABLE_IDENTIFIER_FIELD_DOC =
+        "Table identifier field which needs to be removed if using consistency mode";
   private static final EnumRecommender QUOTE_METHOD_RECOMMENDER =
       EnumRecommender.in(QuoteMethod.values());
 
@@ -512,6 +518,22 @@ public class JdbcSinkConfig extends AbstractConfig {
           ConfigDef.Width.SHORT,
           CONSISTENT_WRITES_DISPLAY
         )
+        .define(
+          TABLE_IDENTIFIER_FIELD,
+          ConfigDef.Type.STRING,
+          TABLE_IDENTIFIER_FIELD_DEFAULT,
+          ConfigDef.Importance.LOW,
+          TABLE_IDENTIFIER_FIELD_DOC, "",
+          -1,
+          ConfigDef.Width.LONG,
+          CONSISTENT_WRITES_DISPLAY
+        )
+        .defineInternal(
+          REMOVE_TABLE_IDENTIFIER_FIELD,
+          ConfigDef.Type.BOOLEAN,
+          REMOVE_TABLE_IDENTIFIER_FIELD_DEFAULT,
+          ConfigDef.Importance.LOW
+        )
         .defineInternal(
             TRIM_SENSITIVE_LOG_ENABLED,
             ConfigDef.Type.BOOLEAN,
@@ -540,7 +562,8 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final TimeZone timeZone;
   public final EnumSet<TableType> tableTypes;
   public final boolean consistentWrites;
-
+  public final String tableIdentifierField;
+  public final boolean removeTableIdentifierField;
   public final boolean trimSensitiveLogsEnabled;
 
   public JdbcSinkConfig(Map<?, ?> props) {
@@ -572,6 +595,8 @@ public class JdbcSinkConfig extends AbstractConfig {
     }
     tableTypes = TableType.parse(getList(TABLE_TYPES_CONFIG));
     consistentWrites = getBoolean(CONSISTENT_WRITES);
+    tableIdentifierField = getString(TABLE_IDENTIFIER_FIELD);
+    removeTableIdentifierField = getBoolean(REMOVE_TABLE_IDENTIFIER_FIELD);
   }
 
   private String getPasswordValue(String key) {

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -503,7 +503,7 @@ public class JdbcSinkConfig extends AbstractConfig {
           CONSISTENT_WRITES,
           ConfigDef.Type.BOOLEAN,
           CONSISTENT_WRITES_DEFAULT,
-          ConfigDef.Importance.LOW,
+          ConfigDef.Importance.MEDIUM,
           AUTO_CREATE_DOC, DDL_GROUP,
           1,
           ConfigDef.Width.SHORT,
@@ -568,7 +568,7 @@ public class JdbcSinkConfig extends AbstractConfig {
           "Primary key mode must be 'record_key' when delete support is enabled");
     }
     tableTypes = TableType.parse(getList(TABLE_TYPES_CONFIG));
-    consistentWrites = getBoolean(AUTO_CREATE);
+    consistentWrites = getBoolean(CONSISTENT_WRITES);
   }
 
   private String getPasswordValue(String key) {

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -498,7 +498,8 @@ public class JdbcSinkConfig extends AbstractConfig {
             ConfigDef.Width.SHORT,
             RETRY_BACKOFF_MS_DISPLAY
         )
-        .define( // TODO: Add proper doc, group and display parameters to this property.
+        // TODO: Add proper doc, group and display parameters to this property.
+        .define(
           CONSISTENT_WRITES,
           ConfigDef.Type.BOOLEAN,
           CONSISTENT_WRITES_DEFAULT,

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -257,6 +257,9 @@ public class JdbcSinkConfig extends AbstractConfig {
 
   public static final String TRIM_SENSITIVE_LOG_ENABLED = "trim.sensitive.log";
   private static final String TRIM_SENSITIVE_LOG_ENABLED_DEFAULT = "false";
+
+  private static final String CONSISTENT_WRITES = "consistent.writes";
+  private static final String CONSISTENT_WRITES_DEFAULT = "false";
   private static final EnumRecommender QUOTE_METHOD_RECOMMENDER =
       EnumRecommender.in(QuoteMethod.values());
 
@@ -495,6 +498,16 @@ public class JdbcSinkConfig extends AbstractConfig {
             ConfigDef.Width.SHORT,
             RETRY_BACKOFF_MS_DISPLAY
         )
+        .define( // TODO: Add proper doc, group and display parameters to this property.
+          CONSISTENT_WRITES,
+          ConfigDef.Type.BOOLEAN,
+          CONSISTENT_WRITES_DEFAULT,
+          ConfigDef.Importance.LOW,
+          AUTO_CREATE_DOC, DDL_GROUP,
+          1,
+          ConfigDef.Width.SHORT,
+          AUTO_CREATE_DISPLAY
+        )
         .defineInternal(
             TRIM_SENSITIVE_LOG_ENABLED,
             ConfigDef.Type.BOOLEAN,
@@ -522,6 +535,7 @@ public class JdbcSinkConfig extends AbstractConfig {
   public final String dialectName;
   public final TimeZone timeZone;
   public final EnumSet<TableType> tableTypes;
+  public final boolean consistentWrites;
 
   public final boolean trimSensitiveLogsEnabled;
 
@@ -553,6 +567,7 @@ public class JdbcSinkConfig extends AbstractConfig {
           "Primary key mode must be 'record_key' when delete support is enabled");
     }
     tableTypes = TableType.parse(getList(TABLE_TYPES_CONFIG));
+    consistentWrites = getBoolean(AUTO_CREATE);
   }
 
   private String getPasswordValue(String key) {

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkConfig.java
@@ -260,6 +260,9 @@ public class JdbcSinkConfig extends AbstractConfig {
 
   private static final String CONSISTENT_WRITES = "consistent.writes";
   private static final String CONSISTENT_WRITES_DEFAULT = "false";
+  private static final String CONSISTENT_WRITES_DOC =
+      "Whether to use consistency mode or not";
+  private static final String CONSISTENT_WRITES_DISPLAY = "Consistent-Writes";
   private static final EnumRecommender QUOTE_METHOD_RECOMMENDER =
       EnumRecommender.in(QuoteMethod.values());
 
@@ -504,10 +507,10 @@ public class JdbcSinkConfig extends AbstractConfig {
           ConfigDef.Type.BOOLEAN,
           CONSISTENT_WRITES_DEFAULT,
           ConfigDef.Importance.MEDIUM,
-          AUTO_CREATE_DOC, DDL_GROUP,
-          1,
+          CONSISTENT_WRITES_DOC, "",
+          -1,
           ConfigDef.Width.SHORT,
-          AUTO_CREATE_DISPLAY
+          CONSISTENT_WRITES_DISPLAY
         )
         .defineInternal(
             TRIM_SENSITIVE_LOG_ENABLED,

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -87,7 +87,7 @@ public class JdbcSinkTask extends SinkTask {
         recordsCount, first.topic(), first.kafkaPartition(), first.kafkaOffset()
     );
     try {
-      writer.write(records);
+      writer.writeConsistently(records);
     } catch (TableAlterOrCreateException tace) {
       if (reporter != null) {
         unrollAndRetry(records);
@@ -141,7 +141,7 @@ public class JdbcSinkTask extends SinkTask {
     initWriter();
     for (SinkRecord record : records) {
       try {
-        writer.write(Collections.singletonList(record));
+        writer.writeConsistently(Collections.singletonList(record));
       } catch (TableAlterOrCreateException tace) {
         log.debug(tace.toString());
         reporter.report(record, tace);

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -50,6 +50,7 @@ public class JdbcSinkTask extends SinkTask {
   public void start(final Map<String, String> props) {
     log.info("Starting JDBC Sink task");
     config = new JdbcSinkConfig(props);
+    log.info("Consistent write status in sink: " + config.consistentWrites);
     initWriter();
     remainingRetries = config.maxRetries;
     shouldTrimSensitiveLogs = config.trimSensitiveLogsEnabled;

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcSinkTask.java
@@ -87,7 +87,11 @@ public class JdbcSinkTask extends SinkTask {
         recordsCount, first.topic(), first.kafkaPartition(), first.kafkaOffset()
     );
     try {
-      writer.writeConsistently(records);
+      if (config.consistentWrites) {
+        writer.writeConsistently(records);
+      } else {
+        writer.write(records);
+      }
     } catch (TableAlterOrCreateException tace) {
       if (reporter != null) {
         unrollAndRetry(records);
@@ -141,7 +145,11 @@ public class JdbcSinkTask extends SinkTask {
     initWriter();
     for (SinkRecord record : records) {
       try {
-        writer.writeConsistently(Collections.singletonList(record));
+        if (config.consistentWrites) {
+          writer.writeConsistently(Collections.singletonList(record));
+        } else {
+          writer.write(Collections.singletonList(record));
+        }
       } catch (TableAlterOrCreateException tace) {
         log.debug(tace.toString());
         reporter.report(record, tace);

--- a/src/test/java/io/confluent/connect/jdbc/JdbcSinkConnectorTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/JdbcSinkConnectorTest.java
@@ -41,6 +41,8 @@ public class JdbcSinkConnectorTest {
     connConfig.put("connector.class", "io.confluent.connect.jdbc.JdbcSinkConnector");
     connConfig.put("delete.enabled", "true");
 
+    connConfig.put("consistent.writes", "true");
+
     connConfig.put("pk.mode", "record_key");
     assertEquals("'pk.mode must be 'RECORD_KEY/record_key' when 'delete.enabled' == true",
         EMPTY_LIST, configErrors(connector.validate(connConfig), PK_MODE));


### PR DESCRIPTION
## Problem
The sink connector buffers records and only flushes them after a while to the target database. This causes issues with consistency as it may cause constraint violations in the target database.

## Solution
To overcome the problem, a logic is implemented in this PR to buffer only till we do not receive a `COMMIT` record in the topic.

### More additions
There are a few new configuration properties also added:
* `consistent.writes` - whether or not the connector should write in consistent mode
* `table.identifier.field` - the field which should be removed while writing in consistent mode, this field is added by the transformer `ByLogicalTableRouter` in the Kafka record and has a value of the table name.
* `remove.table.identifier.field` - whether or not to remove the table identifier field

## Release Plan
This will only be released for Yugabyte's internal testing purposes to validate the CDC consistent streaming.
