### PR TITLE
Rollback txn before each BEGIN record in Consistency mode

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -124,8 +124,9 @@ public class JdbcDbWriter {
                  .collect(Collectors.toSet()).contains("status");
         if (isTxnRecord) {
           if (s.getString("status").equals("BEGIN")) {
-            log.debug("Rolling back transaction as a sanity");
+            // Rolling back transaction as a sanity check just in case there are any uncommitted transactions.
             connection.rollback();
+
             // Do nothing, indicate a connection start.
             log.debug("Received a BEGIN record with transaction id {}, "
                         + "starting to buffer the records", s.getString("id"));

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -124,6 +124,8 @@ public class JdbcDbWriter {
                  .collect(Collectors.toSet()).contains("status");
         if (isTxnRecord) {
           if (s.getString("status").equals("BEGIN")) {
+            log.debug("Rolling back transaction as a sanity");
+            connection.rollback();
             // Do nothing, indicate a connection start.
             log.debug("Received a BEGIN record with transaction id {}, "
                         + "starting to buffer the records", s.getString("id"));

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -135,7 +135,6 @@ public class JdbcDbWriter {
             log.debug("Received a END record, committing the transaction with id {} with "
                         + "total record size {}", s.getString("id"), s.getInt64("event_count"));
             connection.commit();
-            final Struct dataCollections = (Struct) s.getArray("data_collections").get(0);
             if (config.logTableBalance) {
               logTotalBalanceAfterTxnCommit(connection, s.getString("id"));
             }

--- a/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/JdbcDbWriter.java
@@ -124,7 +124,8 @@ public class JdbcDbWriter {
                  .collect(Collectors.toSet()).contains("status");
         if (isTxnRecord) {
           if (s.getString("status").equals("BEGIN")) {
-            // Rolling back transaction as a sanity check just in case there are any uncommitted transactions.
+            // Rolling back transaction as a sanity check just in case there are any
+            // uncommitted transactions.
             connection.rollback();
 
             // Do nothing, indicate a connection start.

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
@@ -632,17 +632,9 @@ public class JdbcDbWriterTest {
   @Test
   public void rollbackUncommittedTxn() throws SQLException {
     String tableName = "books";
-    String createTable = "CREATE TABLE " + tableName + " (" +
-            "     id      INTEGER," +
-            "    author  VARCHAR(50)," +
-            "    title VARCHAR(100)," +
-            ");";
-
-    sqliteHelper.createTable(createTable);
     Map<String, String> props = new HashMap<>();
     props.put("connection.url", sqliteHelper.sqliteUri());
     props.put("auto.create", "true");
-    props.put("auto.evolve", "true");
     props.put("pk.mode", "record_key");
     props.put("pk.fields", "id");
     props.put("consistent.writes", "true");
@@ -679,11 +671,11 @@ public class JdbcDbWriterTest {
 
     // Put the same schema and value in transactional records for ease of use.
     List<SinkRecord> records = new ArrayList<>();
-    records.add(new SinkRecord("topic", 0, txnSchema, beginStruct, txnSchema, beginStruct, 0));
-    records.add(new SinkRecord("topic", 0, keySchema, keyStruct1, valueSchema, valueStruct1, 1));
-    records.add(new SinkRecord("topic", 0, txnSchema, beginStruct, txnSchema, beginStruct, 2));
-    records.add(new SinkRecord("topic", 0, keySchema, keyStruct2, valueSchema, valueStruct2, 3));
-    records.add(new SinkRecord("topic", 0, txnSchema, endStruct, txnSchema, endStruct, 4));
+    records.add(new SinkRecord(tableName, 0, txnSchema, beginStruct, txnSchema, beginStruct, 0));
+    records.add(new SinkRecord(tableName, 0, keySchema, keyStruct1, valueSchema, valueStruct1, 1));
+    records.add(new SinkRecord(tableName, 0, txnSchema, beginStruct, txnSchema, beginStruct, 2));
+    records.add(new SinkRecord(tableName, 0, keySchema, keyStruct2, valueSchema, valueStruct2, 3));
+    records.add(new SinkRecord(tableName, 0, txnSchema, endStruct, txnSchema, endStruct, 4));
     writer.writeConsistently(records);
 
     assertEquals(

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
@@ -630,7 +630,7 @@ public class JdbcDbWriterTest {
   }
 
   @Test
-  public void rollbackUncommittedTxn() throws SQLException {
+  public void rollbackUncommittedTxnInConsistencyMode() throws SQLException {
     String tableName = "books";
     Map<String, String> props = new HashMap<>();
     props.put("connection.url", sqliteHelper.sqliteUri());

--- a/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/sink/JdbcDbWriterTest.java
@@ -629,4 +629,75 @@ public class JdbcDbWriterTest {
                    + "(SELECT balance FROM table_a) AS subquery;", writer.getBalanceQuery());
   }
 
+  @Test
+  public void rollbackUncommittedTxn() throws SQLException {
+    String tableName = "books";
+    String createTable = "CREATE TABLE " + tableName + " (" +
+            "     id      INTEGER," +
+            "    author  VARCHAR(50)," +
+            "    title VARCHAR(100)," +
+            ");";
+
+    sqliteHelper.createTable(createTable);
+    Map<String, String> props = new HashMap<>();
+    props.put("connection.url", sqliteHelper.sqliteUri());
+    props.put("auto.create", "true");
+    props.put("auto.evolve", "true");
+    props.put("pk.mode", "record_key");
+    props.put("pk.fields", "id");
+    props.put("consistent.writes", "true");
+
+    writer = newWriter(props);
+
+    Schema keySchema = SchemaBuilder.struct()
+            .field("id", Schema.INT32_SCHEMA);
+    Struct keyStruct1 = new Struct(keySchema)
+            .put("id", 1);
+    Struct keyStruct2 = new Struct(keySchema)
+            .put("id", 2);
+
+    Schema valueSchema = SchemaBuilder.struct()
+            .field("author", Schema.STRING_SCHEMA)
+            .field("title", Schema.STRING_SCHEMA)
+            .field("__dbz_physicalTableIdentifier", Schema.STRING_SCHEMA)
+            .build();
+
+    Struct valueStruct1 = new Struct(valueSchema)
+            .put("author", "Tom Robbins")
+            .put("title", "Villa Incognito")
+            .put("__dbz_physicalTableIdentifier", "books");
+    Struct valueStruct2 = new Struct(valueSchema)
+            .put("author", "George Orwell")
+            .put("title", "Animal Farm")
+            .put("__dbz_physicalTableIdentifier", "books");
+
+    Schema txnSchema = SchemaBuilder.struct()
+            .field("status", Schema.STRING_SCHEMA);
+    Struct beginStruct = new Struct(txnSchema).put("status", "BEGIN");
+
+    Struct endStruct = new Struct(txnSchema).put("status", "END");
+
+    // Put the same schema and value in transactional records for ease of use.
+    List<SinkRecord> records = new ArrayList<>();
+    records.add(new SinkRecord("topic", 0, txnSchema, beginStruct, txnSchema, beginStruct, 0));
+    records.add(new SinkRecord("topic", 0, keySchema, keyStruct1, valueSchema, valueStruct1, 1));
+    records.add(new SinkRecord("topic", 0, txnSchema, beginStruct, txnSchema, beginStruct, 2));
+    records.add(new SinkRecord("topic", 0, keySchema, keyStruct2, valueSchema, valueStruct2, 3));
+    records.add(new SinkRecord("topic", 0, txnSchema, endStruct, txnSchema, endStruct, 4));
+    writer.writeConsistently(records);
+
+    assertEquals(
+            1,
+            sqliteHelper.select("select * from books", new SqliteHelper.ResultSetReadCallback() {
+              @Override
+              public void read(ResultSet rs) throws SQLException {
+                assertEquals(keyStruct2.getInt32("id").byteValue(), rs.getInt("id"));
+                assertEquals(valueStruct2.getString("author"), rs.getString("author"));
+                assertEquals(valueStruct2.getString("title"), rs.getString("title"));
+              }
+            })
+    );
+  }
+
+
 }


### PR DESCRIPTION
## Problem
Consider the following scenario:
Sink connector, deployed in consistency mode, received the following records in the order:
1. BEGIN of txn1
2. DML of txn1
3. BEGIN of txn2
4. DML of txn2
5. COMMIT of txn2

Sink connector, without this fix, will apply record of txn1 as well which is incorrect since it didnt receive a commit of txn1. 


## Solution

Whenever a BEGIN record is received by the sink connector, we will rollback as a sanity check to avoid applying records of any existing uncommitted txns. 

## Testing
mvn clean test -Dcheckstyle.skip  -Dtest=JdbcDbWriterTest#rollbackUncommittedTxn


## Release Plan
This will only be released for Yugabyte's internal testing purposes to validate the CDC consistent streaming.